### PR TITLE
fix: return back crypto-bigint with default-features = false

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "BSD-3-Clause"
 name = "ed448-goldilocks-plus"
 readme = "README.md"
 repository = "https://github.com/mikelodder7/Ed448-Goldilocks"
-version = "0.13.2"
+version = "0.13.3"
 
 [dependencies]
 crypto-bigint = { version = "0.5.5", features = ["generic-array"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/mikelodder7/Ed448-Goldilocks"
 version = "0.13.2"
 
 [dependencies]
+crypto-bigint = { version = "0.5.5", features = ["generic-array"], default-features = false }
 elliptic-curve = { version = "0.13", features = ["arithmetic", "bits", "hash2curve", "hazmat", "jwk", "pkcs8", "pem", "sec1"] }
 subtle = { version = "2.6", default-features = false }
 rand_core = { version = "0.6", default-features = false }


### PR DESCRIPTION
@mikelodder7 I figured out why my CI is crashing: `cargo update -Z minimal-versions` forcing an old version of `crypto-bigint`. The solution is to bring it back, but with `default-features = false`. Appreciate your quick response & publishing to crates.io! :heart:

I also recommend enable CI for this repo: https://github.com/mikelodder7/Ed448-Goldilocks/pull/3#issuecomment-2551918650